### PR TITLE
[fix]: renamed font-manager-redux ts module declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'font-manager-redux' {
+declare module 'fontmanager-redux' {
     export interface FontDescriptor {
         readonly path: string;
         readonly style: string;


### PR DESCRIPTION
At this this current state we can't use typings on your library because the module declaration was named `font-manager-redux` instead of `fontmanager-redux`